### PR TITLE
Use BoundingClientRect to get element position

### DIFF
--- a/src/hooks/useInViewScroll.ts
+++ b/src/hooks/useInViewScroll.ts
@@ -25,7 +25,7 @@ export const useInViewScroll = (
 
       const threshold = options.threshold || 0
 
-      const elPosY = node.offsetTop
+      const elPosY = node.getBoundingClientRect().top + scrollY.get()
       const elHeight = node.scrollHeight
 
       const viewIntersect = Math.max(elPosY - window.innerHeight, 0)


### PR DESCRIPTION
Use getBoundingClientRect() instead of offsetTop because of issues when using this hook against absolutely positioned elements